### PR TITLE
#165536047 fix error on docker image update(circle ci)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ jobs:
           command: docker push shopinc/iam-server:0.0.1
       - run:
           name: Logout of docker hub
-          command: docker logoutUser $DOCKER_REGISTRY
+          command: docker logout $DOCKER_REGISTRY 
       - *persist_to_workspace
 
 workflows:

--- a/server/procedures/index.ts
+++ b/server/procedures/index.ts
@@ -8,7 +8,7 @@ const procedures = {
   createUser,
   loginUser,
   verifyUser,
-  logout: logoutUser,
+  logoutUser,
 };
 
 export default procedures;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "esModuleInterop": true,
     "target": "es6",
-    "noImplicitAny": true,
+    "noImplicitAny": false,
     "moduleResolution": "node",
     "sourceMap": true,
     "outDir": "dist",


### PR DESCRIPTION
#### What does this PR do?
Fixes an error that prevents automatic update on `shopinc/iam-server:0.0.1` hosted on docker hub.

#### Description of Task to be completed?
  - remove the non-existent command of logoutUser in circle ci
  - replace with logout

#### How should this be manually tested?
Once a PR is merged, the Circle CI task for building and updating the docker image will be triggered hence the image will be updated.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
* [#165536047](https://www.pivotaltracker.com/story/show/165536047)

#### Screenshots (if appropriate)
N/A
#### Questions:
